### PR TITLE
Add README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Dragon plugin for the Advanced Reactor Modeling Interface (ARMI)
+This ARMI plugin provides mechanisms for ARMI applications to drive the [Dragon
+lattice physics code](https://www.polymtl.ca/merlin/version5.htm) from École
+Polytechnique de Montréal.
+
+More details of how to install and use this plugin to come!


### PR DESCRIPTION
This is of course incomplete, but as the lack of a README.md is causing the setup script to fail, we need something in there sooner rather than later. Also, once we get an example app pushed up, we can add some links to that.