### PR TITLE
Setup fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.pyx
 
 # No built binary files
+*.egg-info
 build
 *.lib
 *.dll

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 
 """Setup.py script for TerraPower DRAGON ARMI plugin"""
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 with open("README.md") as f:
     README = f.read()
@@ -26,7 +26,7 @@ setup(
     author="TerraPower LLC",
     author_email="armi-devs@terrapower.com",
     url="https://github.com/terrapower/dragon-plugin",
-    packages=find_packages(),
+    packages=find_namespace_packages(),
     license="Apache 2.0",
     long_description=README,
     install_requires=["armi", "numpy", "scipy"],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=find_namespace_packages(),
     license="Apache 2.0",
     long_description=README,
-    install_requires=["armi", "numpy", "scipy"],
+    install_requires=["armi", "jinja2"],
     keywords="ARMI, DRAGON",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/terrapower/physics/neutronics/dragon/__init__.py
+++ b/terrapower/physics/neutronics/dragon/__init__.py
@@ -1,2 +1,2 @@
 """This is a namespace package for the Dragon plugin"""
-from . import plugin
+from .plugin import DragonPlugin


### PR DESCRIPTION
This includes a few fixes to get the `setup.py` script working, and adds a re-export of the `DragonPlugin` class from the `dragon` package. This lets someone do `from terrapower.physics.neutronics.dragon import DragonPlugin`