### PR TITLE
Improve multi-mixture capability of DRAGON writer

### DIFF
--- a/doc/dragon.rst
+++ b/doc/dragon.rst
@@ -21,7 +21,8 @@ and ARMI (objects such as block) to a template, and the template is filled out t
 the input file
 
 DRAGON can also model more complex geometry, but users are responsible for creating
-their own template and associated data extraction to model the needed geometry
+their own template and associated code that extracts the required template information
+from the ARMI data model for the desired geometry.
 
 Use
 ---

--- a/doc/dragon.rst
+++ b/doc/dragon.rst
@@ -1,9 +1,9 @@
 Introduction
 ============
 
-This plugin uses data contained in the ARMI reactor model to 
-write DRAGON input files and execute DRAGON on them,
-thereby producing microscopic cross sections in the form of ISOTXS files.
+This plugin uses data contained in the ARMI reactor model to write DRAGON input
+files and execute DRAGON on them, thereby producing microscopic cross sections
+in the form of ISOTXS files.
 
 
 Capabilities
@@ -21,10 +21,10 @@ and ARMI (objects such as block) to a template, and the template is filled out t
 the input file
 
 DRAGON can also model more complex geometry, but users are responsible for creating
-their own template to model the needed geometry
+their own template and associated data extraction to model the needed geometry
 
-Interaction
------------
+Use
+---
 * To turn DRAGON on as the lattice physics tool the setting ``xsKernel`` must be set 
   to ``DRAGON``.
 * For DRAGON to run, the location of your DRAGON executable must be known. The location 
@@ -55,8 +55,8 @@ Structure
 ---------
 The DRAGON interface is composed of:
 
-* An interface class responsible for creating new cross sections at the beginning of
+* An interface class responsible for triggering a workflow that creates new cross sections at the beginning of
   each cycle.
-* A writer class which is responsible for writing a DRAGON input file.
-* A template helper class which is responsible for interacting with the template.
+* A writer class which is responsible for building data structures required in a DRAGON input file.
+* A template which renders the inputs data structures the input file format.
 * An executor class, which is responsible for executing DRAGON.

--- a/terrapower/physics/neutronics/dragon/__init__.py
+++ b/terrapower/physics/neutronics/dragon/__init__.py
@@ -1,2 +1,6 @@
-"""This is a namespace package for the Dragon plugin"""
+"""
+The DRAGON plugin.
+
+This is a namespace package for running DRAGON.
+"""
 from .plugin import DragonPlugin

--- a/terrapower/physics/neutronics/dragon/dragonExecutor.py
+++ b/terrapower/physics/neutronics/dragon/dragonExecutor.py
@@ -143,19 +143,8 @@ class DragonExecuter:
 
     def writeInput(self):
         """Write the input file."""
-        inWriterCls = self._chooseInputWriter()
-        inputWriter = inWriterCls([self.block], self.options)
+        inputWriter = dragonFactory.makeWriter([self.block], self.options)
         inputWriter.write()
-
-    def _chooseInputWriter(self):  # pylint: disable=no-self-use; useful in override
-        """
-        Select an input writer class.
-        
-        Notes
-        -----
-        Intended to be customized via subclassing.
-        """
-        return dragonWriter.DragonWriter
 
     def _execute(self):
         """
@@ -201,3 +190,6 @@ class DragonExecuter:
             outputPaths,
             executeDragon,
         )
+
+
+from .dragonFactory import dragonFactory

--- a/terrapower/physics/neutronics/dragon/dragonExecutor.py
+++ b/terrapower/physics/neutronics/dragon/dragonExecutor.py
@@ -138,6 +138,7 @@ class DragonExecuter:
             self.options.outputFile,
             # rename isotxs on way back to the shared directory
             (self.options.outputIsotxsName, f"ISO{self.options.xsID}"),
+            "*.ps",
         )
         return inputs, outputs
 

--- a/terrapower/physics/neutronics/dragon/dragonExecutor.py
+++ b/terrapower/physics/neutronics/dragon/dragonExecutor.py
@@ -42,7 +42,6 @@ from . import settings
 
 # DRAGON natively names the ISOTXS file "ISOTXS000001".
 ISOTXS_NAME = "ISOTXS{:06d}"
-THIS_DIR = os.path.dirname(__file__)
 
 
 class DragonOptions(executers.ExecutionOptions):
@@ -66,10 +65,6 @@ class DragonOptions(executers.ExecutionOptions):
         # only expecting 1 ISOTXS at the moment
         self.outputIsotxsName = ISOTXS_NAME.format(1)
 
-        self.templatePath = os.path.join(
-            THIS_DIR, "resources", "DRAGON_Template_0D.txt"
-        )
-
     def fromUserSettings(self, cs: caseSettings.Settings):
         """Load settings from a case settings object"""
         self.executablePath = shutil.which(cs[settings.CONF_DRAGON_PATH])
@@ -88,6 +83,8 @@ class DragonOptions(executers.ExecutionOptions):
             raise ValueError("You must run `fromBlock` before `fromUserSettings`")
         self.xsSettings = cs[neutronics.const.CONF_CROSS_SECTION][self.xsID]
 
+        self.templatePath = cs[settings.CONF_DRAGON_TEMPLATE_PATH]
+
     def fromReactor(self, reactor):
         self.nuclides = reactor.blueprints.allNuclidesInProblem
 
@@ -98,7 +95,7 @@ class DragonOptions(executers.ExecutionOptions):
 
 class DragonExecuter:
     """
-    Execute a DRAGON case.
+    Execute a DRAGON case given a block.
 
     Notes
     -----
@@ -147,7 +144,7 @@ class DragonExecuter:
     def writeInput(self):
         """Write the input file."""
         inWriterCls = self._chooseInputWriter()
-        inputWriter = inWriterCls(self.block, self.options)
+        inputWriter = inWriterCls([self.block], self.options)
         inputWriter.write()
 
     def _chooseInputWriter(self):  # pylint: disable=no-self-use; useful in override

--- a/terrapower/physics/neutronics/dragon/dragonFactory.py
+++ b/terrapower/physics/neutronics/dragon/dragonFactory.py
@@ -1,4 +1,14 @@
-"""Factory for building DRAGON related objects and their subclasses"""
+"""
+Factory for building DRAGON related objects and their subclasses.
+
+This is an attempt at using an Abstract Factory pattern to allow
+applications to configure the dragon plugin as they see necessary. 
+Choosing which writer subclasses to use has to be done at some level. 
+This factory allows an app to configure its choices in a global
+instance of this abstract factory. At some later date it may 
+make sense for ARMI to provide a common way for plugins
+to self-configure. .
+"""
 
 
 class DragonFactory:

--- a/terrapower/physics/neutronics/dragon/dragonFactory.py
+++ b/terrapower/physics/neutronics/dragon/dragonFactory.py
@@ -1,0 +1,48 @@
+"""Factory for building DRAGON related objects and their subclasses"""
+
+
+class DragonFactory:
+    """
+    Build objects based on registration.
+
+    Enables easy customization of the chain of objects needed without excessive subclassing
+    """
+
+    def __init__(self):
+        self._writers = {}
+        self._executers = {}
+        self._runners = {}
+        self._key = None
+
+    def setKey(self, key):
+        """Apply a key to this factory to choose classes with."""
+        self._key = key
+
+    def copyEntriesToKey(self, newKey):
+        """Copy current registrations into a new key."""
+        self._writers[newKey] = self._writers[self._key]
+        self._executers[newKey] = self._executers[self._key]
+        self._runners[newKey] = self._runners[self._key]
+
+    def registerRunner(self, key, cls):
+        self._runners[key] = cls
+
+    def registerWriter(self, key, cls):
+        self._writers[key] = cls
+
+    def registerExecuter(self, key, cls):
+        self._executers[key] = cls
+
+    def makeRunner(self, objsToRun):
+        return self._runners[self._key](objsToRun)
+
+    def makeExecuter(self, opts, obj):
+        """Return a new Executer instance."""
+        return self._executers[self._key](opts, obj)
+
+    def makeWriter(self, objs, options):
+        """Return a new writer instance"""
+        return self._writers[self._key](objs, options)
+
+
+dragonFactory = DragonFactory()

--- a/terrapower/physics/neutronics/dragon/dragonInterface.py
+++ b/terrapower/physics/neutronics/dragon/dragonInterface.py
@@ -53,9 +53,9 @@ class DragonRunner(mpiActions.MpiAction):
             self.r.syncMpiState()
 
     def _buildExecuterForBlock(self, b):
+        """Build options and executers for a block."""
         from . import dragonExecutor
 
-        """Build options and executers for a block."""
         opts = dragonExecutor.DragonOptions(
             label=f"dragon-{b.getName()}-{self.r.p.cycle}-{self.r.p.timeNode}"
         )

--- a/terrapower/physics/neutronics/dragon/dragonInterface.py
+++ b/terrapower/physics/neutronics/dragon/dragonInterface.py
@@ -24,7 +24,47 @@ from armi.physics.neutronics.latticePhysics import latticePhysicsInterface
 from armi.nuclearDataIO import xsLibraries
 from armi import mpiActions
 
-from . import dragonExecutor
+from .settings import CONF_OPT_DRAGON
+
+
+class DragonRunner(mpiActions.MpiAction):
+    """
+    Run a set of DRAGON runs, possibly in parallel.
+
+    MpiActions have access to the operator and the reactor and can therefore
+    reach in as appropriate to select which blocks to execute on in a 
+    analysis-specific way.
+
+    Builds DragonExecuters to run each individual case.
+    """
+
+    def __init__(self, objsToRun):
+        mpiActions.MpiAction.__init__(self)
+        self._objs = objsToRun
+
+    def invokeHook(self):
+        """Perform DRAGON calculation for the blocks assigned to this process."""
+        for b in self.mpiIter(self._objs):
+            executer = self._buildExecuterForBlock(b)
+            executer.run()
+
+        if self.parallel:
+            self.gather()
+            self.r.syncMpiState()
+
+    def _buildExecuterForBlock(self, b):
+        from . import dragonExecutor
+
+        """Build options and executers for a block."""
+        opts = dragonExecutor.DragonOptions(
+            label=f"dragon-{b.getName()}-{self.r.p.cycle}-{self.r.p.timeNode}"
+        )
+
+        opts.fromReactor(self.r)
+        opts.fromBlock(b)
+        opts.fromUserSettings(self.cs)
+
+        return dragonFactory.makeExecuter(opts, b)
 
 
 class DragonInterface(interfaces.Interface):
@@ -33,12 +73,25 @@ class DragonInterface(interfaces.Interface):
     name = "dragon"  # name is required for all interfaces
     function = latticePhysicsInterface.LATTICE_PHYSICS
 
+    def __init__(self, r, cs):
+        interfaces.Interface.__init__(self, r, cs)
+        # pylint: disable=wrong-import-position; avoid circular imports
+        from .dragonExecutor import DragonExecuter
+        from .dragonWriter import DragonWriterHomogenized
+
+        # register built-in objects. You can add your own in your app/plugins.
+        dragonFactory.registerExecuter(CONF_OPT_DRAGON, DragonExecuter)
+        dragonFactory.registerWriter(CONF_OPT_DRAGON, DragonWriterHomogenized)
+        dragonFactory.registerRunner(CONF_OPT_DRAGON, DragonRunner)
+        dragonFactory.setKey(CONF_OPT_DRAGON)
+
     def interactBOC(self, cycle=None):
         """Run DRAGON on various representative blocks, producing microscopic cross sections."""
-        runLog.info("Running DRAGON to update cross sections.")
+        runLog.info(f"Running DRAGON to update cross sections with {self.name}.")
         mpiActions.DistributeStateAction.invokeAsMaster(self.o, self.r, self.cs)
 
-        dragonRunner = DragonRunner()
+        objsToRun = self.selectObjsToRun()
+        dragonRunner = dragonFactory.makeRunner(objsToRun)
         # Run on any potential worker mpi nodes
         dragonRunner.broadcast()
         # Run on this process as well
@@ -57,45 +110,13 @@ class DragonInterface(interfaces.Interface):
 
         isotxs.writeBinary(lib, neutronics.ISOTXS)
 
-
-class DragonRunner(mpiActions.MpiAction):
-    """
-    Run a set of DRAGON runs, possibly in parallel.
-
-    MpiActions have access to the operator and the reactor and can therefore
-    reach in as appropriate to select which blocks to execute on in a 
-    analysis-specific way.
-
-    Builds DragonExecuters to run each individual case.
-    """
-
-    def invokeHook(self):
-        """Perform DRAGON calculation for the blocks assigned to this process."""
-        for b in self.mpiIter(selectBlocksToRun(self.o)):
-            executer = self._buildExecuterForBlock(b)
-            executer.run()
-
-        if self.parallel:
-            self.gather()
-            self.r.syncMpiState()
-
-    def _buildExecuterForBlock(self, b):
-        """Build options and executers for a block."""
-        opts = dragonExecutor.DragonOptions(
-            label=f"dragon-{b.getName()}-{self.r.p.cycle}-{self.r.p.timeNode}"
-        )
-
-        opts.fromReactor(self.r)
-        opts.fromBlock(b)
-        opts.fromUserSettings(self.cs)
-
-        return dragonExecutor.DragonExecuter(opts, b)
+    def selectObjsToRun(self):
+        """Choose blocks that will be passed for DRAGON analysis."""
+        dragonBlocks = []
+        xsGroupManager = self.o.getInterface("xsGroups")
+        for block in xsGroupManager.representativeBlocks.values():
+            dragonBlocks.append(block)
+        return dragonBlocks
 
 
-def selectBlocksToRun(o):
-    """Choose blocks that will be passed for DRAGON analysis."""
-    dragonBlocks = []
-    xsGroupManager = o.getInterface("xsGroups")
-    for block in xsGroupManager.representativeBlocks.values():
-        dragonBlocks.append(block)
-    return dragonBlocks
+from .dragonFactory import dragonFactory

--- a/terrapower/physics/neutronics/dragon/dragonWriter.py
+++ b/terrapower/physics/neutronics/dragon/dragonWriter.py
@@ -130,7 +130,9 @@ class DragonWriterHomogenized(DragonWriter):
 
     def _makeMixtures(self):
         """Make a DragonMixture from each object slated for inclusion in the input."""
-        return [DragonMixture(obj, self.options) for obj in self.armiObjs]
+        return [
+            DragonMixture(obj, self.options, i) for i, obj in enumerate(self.armiObjs)
+        ]
 
 
 class DragonMixture:
@@ -145,9 +147,10 @@ class DragonMixture:
 
     """
 
-    def __init__(self, armiObj, options):
+    def __init__(self, armiObj, options, index):
         self.armiObj = armiObj
         self.options = options
+        self.index = index
 
     def getTempInK(self):
         """
@@ -213,7 +216,8 @@ class DragonMixture:
             )
         return nucData
 
-    def getSelfShieldingFlag(self, nucBase, nDens):  # pylint: disable=unused-argument
+    # pylint: disable=unused-argument
+    def getSelfShieldingFlag(self, nucBase, nDens) -> str:
         """
         Get self shielding flag for a given nuclide.
 
@@ -222,9 +226,11 @@ class DragonMixture:
         creators to apply their own judgment.
         There is some basic data that templates filter out of
         self shielding (SS) calculation, or apply different inrs to nuclides.
+
+        Need index to make sure each mixture gets different fine-group flux.
         """
-        if nucBase.isHeavyMetal() or self.armiObj.density() > 0.01:
-            return "1"
+        if nucBase.isHeavyMetal() or self.armiObj.density() > 0.0001:
+            return f"{self.index + 1}"
         return ""
 
 

--- a/terrapower/physics/neutronics/dragon/dragonWriter.py
+++ b/terrapower/physics/neutronics/dragon/dragonWriter.py
@@ -171,7 +171,11 @@ class DragonMixture:
         """
         avgNum = 0.0
         avgDenom = 0.0
-        for fuel in self.armiObj.getChildrenWithFlags(Flags.FUEL):
+        if any(self.armiObj.doChildrenHaveFlags(Flags.FUEL)):
+            typeSpec = Flags.FUEL
+        else:
+            typeSpec = None
+        for fuel in self.armiObj.iterComponents(typeSpec):
             vol = fuel.getArea()
             avgNum += fuel.temperatureInC * vol
             avgDenom += vol

--- a/terrapower/physics/neutronics/dragon/plugin.py
+++ b/terrapower/physics/neutronics/dragon/plugin.py
@@ -18,8 +18,8 @@ DRAGON Plugin
 from armi import plugins
 from armi import interfaces
 
-from . import dragonInterface
 from . import settings
+
 
 ORDER = interfaces.STACK_ORDER.CROSS_SECTIONS
 
@@ -31,6 +31,8 @@ class DragonPlugin(plugins.ArmiPlugin):
     @plugins.HOOKIMPL
     def exposeInterfaces(cs):
         """Function for exposing interface(s) to other code"""
+        from . import dragonInterface
+
         if cs["xsKernel"] == "DRAGON":
             klass = dragonInterface.DragonInterface
             return [interfaces.InterfaceInfo(ORDER, klass, {})]

--- a/terrapower/physics/neutronics/dragon/resources/DRAGON_Template_0D.txt
+++ b/terrapower/physics/neutronics/dragon/resources/DRAGON_Template_0D.txt
@@ -52,13 +52,13 @@ LIBRARY := LIB: ::
   NMIX {{mixtures|length}} CTRA WIMS
   ! Only 8 chars allowed. Actual data used: {{ nucDataComment }}
   MIXS LIB: DRAGON FIL: {{ nucData }} 
-{%- for mixture in mixtures -%}
+{% for mixture in mixtures %}
   MIX {{loop.index}} {{"{:5f}".format(mixture.getTempInK())}}
 {%- for mixNuc in mixture.getMixVector() -%}
 {{"\n   {:>5}{:2} = {:>7}   {:.6E} {:>3}".format(
 mixNuc.armiName, mixNuc.xsid, mixNuc.dragName, mixNuc.ndens, mixNuc.selfshield)}}
-{%- endfor %}
-{%- endfor %}
+{%- endfor -%}
+{% endfor %}
   ;
 *----
 *  Geometry HOM : Homogeneous geometry

--- a/terrapower/physics/neutronics/dragon/resources/DRAGON_Template_0D.txt
+++ b/terrapower/physics/neutronics/dragon/resources/DRAGON_Template_0D.txt
@@ -49,13 +49,15 @@ MODULE
 *----
 LIBRARY := LIB: ::
   ANIS 2
-  NMIX 1 CTRA WIMS
+  NMIX {{mixtures|length}} CTRA WIMS
   ! Only 8 chars allowed. Actual data used: {{ nucDataComment }}
   MIXS LIB: DRAGON FIL: {{ nucData }} 
-  MIX 1 {{"{:5f}".format(tempFuelInKelvin)}}
-{%- for nuclideID, dragonLibNuclide, nDens, selfShieldingFilterData in blockNDensCard -%}
-{{"\n   {:>7} = {:>7}   {:.6E} {:>3}".format(
-nuclideID, dragonLibNuclide, nDens,  1 if selfShieldingFilterData.mixtureMassDensity > 0.01 else "")}}       
+{%- for mixture in mixtures -%}
+  MIX {{loop.index}} {{"{:5f}".format(mixture.getTempInK())}}
+{%- for mixNuc in mixture.getMixVector() -%}
+{{"\n   {:>5}{:2} = {:>7}   {:.6E} {:>3}".format(
+mixNuc.armiName, mixNuc.xsid, mixNuc.dragName, mixNuc.ndens, mixNuc.selfshield)}}
+{%- endfor %}
 {%- endfor %}
   ;
 *----

--- a/terrapower/physics/neutronics/dragon/settings.py
+++ b/terrapower/physics/neutronics/dragon/settings.py
@@ -16,19 +16,18 @@
 import os
 import shutil
 
-from voluptuous import Schema, Any
-
 from armi.utils import units
 from armi.settings import setting
 from armi.operators import settingsValidation
 from armi.physics.neutronics import settings as neutronicsSettings
-from armi.utils import pathTools
 
 CONF_DRAGON_PATH = "dragonExePath"
 CONF_DRAGON_DATA_PATH = "dragonDataPath"
-CONF_DRAGON_TEMPLATE_HELPER = "dragonTemplateHelper"
+CONF_DRAGON_TEMPLATE_PATH = "dragonTemplatePath"
 
 CONF_OPT_DRAGON = "DRAGON"
+
+THIS_DIR = os.path.dirname(__file__)
 
 
 def defineSettings():
@@ -48,11 +47,10 @@ def defineSettings():
             description="Path to the DRAGON nuclear data file to use.",
         ),
         setting.Setting(
-            CONF_DRAGON_TEMPLATE_HELPER,
-            schema=Schema(Any(str, None)),  # Allow None type
-            default=None,
-            label="DRAGON template helper path",
-            description="Path to module responsible for pointing to the DRAGON template",
+            CONF_DRAGON_TEMPLATE_PATH,
+            default=os.path.join(THIS_DIR, "resources", "DRAGON_Template_0D.txt"),
+            label="DRAGON template path",
+            description="Path to the DRAGON template to be rendered",
         ),
     ]
     return settings
@@ -96,15 +94,11 @@ def defineValidators(inspector):
             inspector.NO_ACTION,
         ),
         settingsValidation.Query(
-            lambda: inspector.cs[CONF_DRAGON_TEMPLATE_HELPER] is not None
-            and not pathTools.moduleAndAttributeExist(
-                inspector.cs[CONF_DRAGON_TEMPLATE_HELPER]
-            ),
-            "Could not find the DRAGON template helper class described {}. Run will"
-            "likely fail during lattice physics calculation.".format(
-                inspector.cs[CONF_DRAGON_TEMPLATE_HELPER]
-            ),
-            "Please update path to point to a module and class that exist.",
+            lambda: not os.path.exists(inspector.cs[CONF_DRAGON_TEMPLATE_PATH]),
+            "The path specified to the DRAGON template file in the "
+            f"`{CONF_DRAGON_TEMPLATE_PATH}` setting does not exist: "
+            f"{inspector.cs[CONF_DRAGON_TEMPLATE_PATH]}",
+            "Please update to the correct location.",
             inspector.NO_ACTION,
         ),
     ]

--- a/terrapower/physics/neutronics/dragon/tests/test_dragonWriter.py
+++ b/terrapower/physics/neutronics/dragon/tests/test_dragonWriter.py
@@ -1,0 +1,75 @@
+"""Unit tests for writers"""
+import unittest
+import os
+
+from armi.reactor.tests.test_blocks import loadTestBlock
+from armi.nucDirectory import nuclideBases
+from armi.utils import units
+from armi.settings import caseSettings
+from armi.physics.neutronics.const import CONF_CROSS_SECTION
+from armi.reactor.flags import Flags
+
+from terrapower.physics.neutronics.dragon import dragonWriter
+from terrapower.physics.neutronics.dragon import dragonExecutor
+
+
+class TestWriter(unittest.TestCase):
+    def setUp(self):
+        block = loadTestBlock()
+        self.cs = caseSettings.Settings()
+        self.cs[CONF_CROSS_SECTION].setDefaults(self.cs)
+        self.cs["dragonDataPath"] = os.path.join("path", "to", "draglibendfb7r1SHEM361")
+        options = dragonExecutor.DragonOptions("test")
+        options.fromBlock(block)
+        options.fromUserSettings(self.cs)
+        self.writer = dragonWriter.DragonWriterHomogenized([block], options)
+
+    def test_templateData(self):
+        """
+        Test that the template data structure is properly defined.
+        """
+        data = self.writer._buildTemplateData()  # pylint: disable=protected-access
+        self.assertEqual(data["xsId"], "AA")
+        self.assertLess(
+            len(data["nucData"]), dragonWriter.N_CHARS_ALLOWED_IN_LIB_NAME + 1
+        )
+        self.assertEqual(data["nucDataComment"], self.cs["dragonDataPath"])
+        self.assertEqual(
+            data["buckling"], bool(self.writer.options.xsSettings.criticalBuckling)
+        )
+        self.assertEqual(
+            len(data["groupStructure"]),
+            len(units.GROUP_STRUCTURE[self.cs["groupStructure"]]) - 1,
+            "DRAGON only includes inner group boundaries so there should be 1 less.",
+        )
+
+
+class TestDragonMixture(unittest.TestCase):
+    def setUp(self):
+        block = loadTestBlock()
+        fuel = block.getChildrenWithFlags(Flags.FUEL)[0]
+        fuel.setTemperature(600)
+        options = dragonExecutor.DragonOptions("test")
+        options.fromBlock(block)
+        options.nuclides = ["U235", "U238"]
+        self.mix = dragonWriter.DragonMixture(block, options)
+
+    def test_mixture(self):
+        self.assertAlmostEqual(self.mix.getTempInK(), 873.15)
+        mixItem = self.mix.getMixVector()[0]
+        self.assertEqual(mixItem.xsid, "AA")
+        self.assertEqual(mixItem.selfshield, "1")
+
+    def test_getDragLibNucID(self):
+        """Test conversion of nuclides to DRAGLIB strings."""
+        am241m = nuclideBases.byName["AM242M"]
+        self.assertEqual(dragonWriter.getDragLibNucID(am241m), "Am242m")
+        u235 = nuclideBases.byName["U235"]
+        self.assertEqual(dragonWriter.getDragLibNucID(u235), "U235")
+        na23 = nuclideBases.byName["NA23"]
+        self.assertEqual(dragonWriter.getDragLibNucID(na23), "Na23")
+
+
+if __name__ == "__main__":
+    # import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()


### PR DESCRIPTION
These changes allow the DragonWriter to accept more than one armi
container object and will write N mixtures containing the number
densities of each one. The code was refactored into several more classes
in an attempt to prepare for easier subclassing and customization. While
mixtures can be added, the current state only writes geometry for the
first region at this point.

* Moved logic about self-shielding flag out of template and into new method
* Changed nuclide data structure from dict to namedtuple for the mixtures
* Moved mixture-specific code from DragonWriter class to new DragonMixture class
* Further split remaining DragonWriter code out as DragonWriterHomogenized to keep the base class free from assumptions
* Changed DragonWriter argument from single block to arbitrary list of objects

Additionally, the changes where the templateHelper concept was replaced
with DragonWriter subclassing were finally updated here. We suspect
users will almost always want a design-specific app going forward and so
we think it's ok to remove the input option that could bring in the
template helper.