### PR TITLE
Starting GitHub Actions with black linter

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -1,0 +1,12 @@
+name: black
+
+on: [push, pull_request]
+
+# use workaround due to: https://github.com/psf/black/issues/2079#issuecomment-812359146
+jobs:
+    check-formatting:
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-python@v2
+            - uses: psf/black@20.8b1

--- a/terrapower/physics/neutronics/dragon/dragonExecutor.py
+++ b/terrapower/physics/neutronics/dragon/dragonExecutor.py
@@ -151,7 +151,7 @@ class DragonExecuter:
     def _execute(self):
         """
         Execute the DRAGON input.
-        
+
         The nuclear data and input are now in current working directory.
 
         Notes

--- a/terrapower/physics/neutronics/dragon/dragonInterface.py
+++ b/terrapower/physics/neutronics/dragon/dragonInterface.py
@@ -32,7 +32,7 @@ class DragonRunner(mpiActions.MpiAction):
     Run a set of DRAGON runs, possibly in parallel.
 
     MpiActions have access to the operator and the reactor and can therefore
-    reach in as appropriate to select which blocks to execute on in a 
+    reach in as appropriate to select which blocks to execute on in a
     analysis-specific way.
 
     Builds DragonExecuters to run each individual case.
@@ -68,7 +68,7 @@ class DragonRunner(mpiActions.MpiAction):
 
 
 class DragonInterface(interfaces.Interface):
-    """"Schedules activities related to DRAGON during ARMI run."""
+    """ "Schedules activities related to DRAGON during ARMI run."""
 
     name = "dragon"  # name is required for all interfaces
     function = latticePhysicsInterface.LATTICE_PHYSICS


### PR DESCRIPTION
This repo will need to run unit tests like ARMI does, using GitHub Actions.

Just to start this process off easy, I am starting with a copy of the `black.yaml` action that we have on ARMI.

Assuming all the plumbing is in place, this should run easy. Then someone can work on the heavier lift of getting unit tests running here.