### PR TITLE
Fixing crash in exposeInterfaces

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 # use workaround due to: https://github.com/psf/black/issues/2079#issuecomment-812359146
 jobs:
     check-formatting:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-python@v2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,14 +8,14 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.13
       - name: Update package index
         run: sudo apt-get update
       - name: Install Pandoc

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -11,10 +11,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: [3.11, 3.12, 3.13]
 
     steps:
       - uses: actions/checkout@v2

--- a/terrapower/physics/neutronics/dragon/dragonExecutor.py
+++ b/terrapower/physics/neutronics/dragon/dragonExecutor.py
@@ -18,7 +18,7 @@ Write input and execute DRAGON given an ARMI object.
 Currently limited to handling Blocks only.
 
 This module makes no assumptions about where the block comes from or when the
-execution is to be performed. 
+execution is to be performed.
 
 Scheduling and choosing happens in
 :py:mod:`terrapower.physics.neutronics/dragon.dragonInterface` in default runs, or

--- a/terrapower/physics/neutronics/dragon/dragonFactory.py
+++ b/terrapower/physics/neutronics/dragon/dragonFactory.py
@@ -16,10 +16,10 @@
 Factory for building DRAGON related objects and their subclasses.
 
 This is an attempt at using an Abstract Factory pattern to allow
-applications to configure the dragon plugin as they see necessary. 
-Choosing which writer subclasses to use has to be done at some level. 
+applications to configure the dragon plugin as they see necessary.
+Choosing which writer subclasses to use has to be done at some level.
 This factory allows an app to configure its choices in a global
-instance of this abstract factory. At some later date it may 
+instance of this abstract factory. At some later date it may
 make sense for ARMI to provide a common way for plugins
 to self-configure. .
 """

--- a/terrapower/physics/neutronics/dragon/plugin.py
+++ b/terrapower/physics/neutronics/dragon/plugin.py
@@ -36,7 +36,7 @@ class DragonPlugin(plugins.ArmiPlugin):
         """Function for exposing interface(s) to other code."""
         from . import dragonInterface
 
-        DragonPlugin.setVersionInSettings(case.cs)
+        DragonPlugin.setVersionInSettings(cs)
 
         if (
             cs[nSettings.CONF_XS_KERNEL] == "DRAGON"


### PR DESCRIPTION
The variable case is not defined in this context
and this crashes immediately. Trivial fix.

Unit tests were failing due to this. Now they pass.